### PR TITLE
Rework digit parsers for failure and provide Word verions

### DIFF
--- a/src/FlatParse/Stateful.hs
+++ b/src/FlatParse/Stateful.hs
@@ -80,6 +80,8 @@ module FlatParse.Stateful (
   , isLatinLetter
   , FlatParse.Stateful.readInt
   , FlatParse.Stateful.readIntHex
+  , FlatParse.Stateful.readWord
+  , FlatParse.Stateful.readWordHex
   , FlatParse.Stateful.readInteger
   , anyCString
 
@@ -708,8 +710,8 @@ anyCharASCII_ :: Parser r e ()
 anyCharASCII_ = () <$ anyCharASCII
 {-# inline anyCharASCII_ #-}
 
--- | Read an `Int` from the input, as a non-empty digit sequence. The `Int` may
---   overflow in the result.
+-- | Read an `Int` from the input, as a non-empty digit sequence.
+-- Fails on overflow.
 readInt :: Parser r e Int
 readInt = Parser \fp r eob s n -> case FlatParse.Internal.readInt eob s of
   (# (##) | #)        -> Fail#
@@ -717,12 +719,28 @@ readInt = Parser \fp r eob s n -> case FlatParse.Internal.readInt eob s of
 {-# inline readInt #-}
 
 -- | Read an `Int` from the input, as a non-empty case-insensitive ASCII
---   hexadecimal digit sequence. The `Int` may overflow in the result.
+--   hexadecimal digit sequence.
+-- Fails on overflow.
 readIntHex :: Parser r e Int
 readIntHex = Parser \fp r eob s n -> case FlatParse.Internal.readIntHex eob s of
   (# (##) | #)        -> Fail#
   (# | (# i, s' #) #) -> OK# (I# i) s' n
 {-# inline readIntHex #-}
+
+-- | Read a `Word` from the input, as a non-empty digit sequence.
+-- Fails on overflow.
+readWord :: Parser r e Int
+readWord = Parser \fp r eob s n -> case FlatParse.Internal.readInt eob s of
+  (# (##) | #)        -> Fail#
+  (# | (# i, s' #) #) -> OK# (I# i) s' n
+{-# inline readWord #-}
+
+readWordHex :: Parser r e Word
+readWordHex = Parser $ \fp r eob s n ->
+  case FlatParse.Internal.readWordHex eob s of
+    (# | (# w, s' #) #) -> OK# (W# w) s' n
+    (# (# #) | #)       -> Fail#
+{-# inline readWordHex #-}
 
 -- | Read an `Integer` from the input, as a non-empty digit sequence.
 readInteger :: Parser r e Integer
@@ -730,7 +748,6 @@ readInteger = Parser \fp r eob s n -> case FlatParse.Internal.readInteger fp eob
   (# (##) | #)        -> Fail#
   (# | (# i, s' #) #) -> OK# i s' n
 {-# inline readInteger #-}
-
 
 --------------------------------------------------------------------------------
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -400,8 +400,14 @@ basicSpec = describe "FlatParse.Basic" $ do
         property $
           \(NonNegative i) -> FB.readInt `shouldParseWith` (FB.packUTF8 (show i), i)
 
+      it "fails on reading an integer out of bounds" $
+        property $
+          \(NonNegative (i :: Int)) -> let i' = fromIntegral i + fromIntegral (maxBound :: Int) + 1
+                                        in FB.readInt `shouldParseFail` FB.packUTF8 (show i')
       it "fails on non-integers" $ FB.readInt `shouldParseFail` "foo"
-      it "fails on negative integers" $ FB.readInt `shouldParseFail` "-5"
+      it "fails on negative integers" $
+        property $
+          \(Negative i) -> FB.readInt `shouldParseFail` (FB.packUTF8 (show i))
       it "fails on FB.empty input" $ FB.readInt `shouldParseFail` ""
 
     describe "readIntHex" $ do
@@ -416,6 +422,20 @@ basicSpec = describe "FlatParse.Basic" $ do
       it "fails on non-integers" $ FB.readIntHex `shouldParseFail` "quux"
       it "fails on negative integers" $ FB.readIntHex `shouldParseFail` "-5"
       it "fails on FB.empty input" $ FB.readIntHex `shouldParseFail` ""
+
+    describe "readWord" $ do
+      it "round-trips on non-negative Words" $
+        property $
+          \(NonNegative i) -> FB.readWord `shouldParseWith` (FB.packUTF8 (show i), i)
+      it "fails on reading an wordeger out of bounds" $
+        property $
+          \(NonNegative (i :: Word)) -> let i' = fromIntegral i + fromIntegral (maxBound :: Word) + 1
+                                        in FB.readWord `shouldParseFail` FB.packUTF8 (show i')
+      it "fails on non-wordegers" $ FB.readWord `shouldParseFail` "foo"
+      it "fails on negative wordegers" $
+        property $
+          \(Negative i) -> FB.readWord `shouldParseFail` (FB.packUTF8 (show i))
+      it "fails on empty input" $ FB.readWord `shouldParseFail` ""
 
     describe "readInteger" $ do
       it "round-trips on non-negative Integers" $


### PR DESCRIPTION
I have reworked the bounded numeric parsers with two features:

a) Provide Word specific parsers (readWord, readWordHex) to allow parsing numbers twice as large.

To read smaller bounded types, a user can simply use something like [intCastMaybe](https://hackage.haskell.org/package/int-cast-0.2.0.0/docs/Data-IntCast.html#v:intCastMaybe) - but to provide broadest compatibility, we should start from `Word`.

b) Have all bounded parsers (readWord, readWordHex, readInt, readIntHex) fail on overflow. 

This feels more rigid and in line with the rest of the library. Note that from the outside an overflow is near impossible to detect reliably.