### PR TITLE
docs (README): fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ outside `flatparse`, and compiled there.
 
 ## Features and non-features
 
-* __Excellent performance__. On microbenchmarks, `flatparse` is around 10 times faster than `attoparsec` or `megaparsec`. On larger examples with heavier use of source positions and spans and/or indentation parsing, the performance difference grows to 20-30 times. Compile times and exectuable sizes are also significantly better with `flatparse` than with `megaparsec` or `attoparsec`. `flatparse` internals make liberal use of unboxed tuples and GHC primops. As a result, pure validators (parsers returning `()`) in `flatparse` are not difficult to implement with zero heap allocation.
+* __Excellent performance__. On microbenchmarks, `flatparse` is around 10 times faster than `attoparsec` or `megaparsec`. On larger examples with heavier use of source positions and spans and/or indentation parsing, the performance difference grows to 20-30 times. Compile times and executable sizes are also significantly better with `flatparse` than with `megaparsec` or `attoparsec`. `flatparse` internals make liberal use of unboxed tuples and GHC primops. As a result, pure validators (parsers returning `()`) in `flatparse` are not difficult to implement with zero heap allocation.
 * __No incremental parsing__, and __only strict `ByteString`__ is supported as input. However, it can be still useful to convert from `Text`, `String` or other types to `ByteString`, and then use `flatparse` for parsing, since `flatparse` performance usually more than makes up for the conversion costs.
 * __Only little-endian 64 bit systems are currently supported as the host machine__. This may change in the future. Getting good performance requires architecture-specific optimizations; I've only considered the most common setting at this point. However, `flatparse` does include specific big-endian parsers for primitive integer types.
 * __Support for fast source location handling, indentation parsing and informative error messages__. `flatparse` provides a low-level interface to these. Batteries are _not included_, but it should be possible for users to build custom solutions, which are more sophisticated, but still as fast as possible. In my experience, the included batteries in other libraries often come with major unavoidable overheads, and often we still have to extend existing machinery in order to scale to production features.
@@ -28,7 +28,7 @@ outside `flatparse`, and compiled there.
 * [`FlatParse.Basic`][basic] only supports the above features. If you don't need indentation
   parsing, this is sufficient.
 * [`FlatParse.Stateful`][stateful] additionally supports a built-in `Int` worth of internal state
-  and an additional custom reader environemnt. This can support a wide range of indentation parsing
+  and an additional custom reader environment. This can support a wide range of indentation parsing
   features. There is a slight overhead in performance and code size compared to `Basic`. However, in
   small parsers and microbenchmarks the difference between `Basic` and `Stateful` is often reduced
   to near zero by GHC and/or LLVM optimization.


### PR DESCRIPTION
(See diff.)