### PR TITLE
state that bytestring takers do not copy

### DIFF
--- a/src/FlatParse/Basic/Base.hs
+++ b/src/FlatParse/Basic/Base.hs
@@ -261,6 +261,9 @@ withEnsure# n# (ParserT p) = ParserT \fp eob s st ->
 -- | Read the given number of bytes as a 'ByteString'.
 --
 -- Throws a runtime error if given a negative integer.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 take :: Int -> ParserT st e B.ByteString
 take (I# n#) = take# n#
 {-# inline take #-}
@@ -269,6 +272,9 @@ take (I# n#) = take# n#
 --   available.
 --
 -- Throws a runtime error if given a negative integer.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 take# :: Int# -> ParserT st e B.ByteString
 take# n# = Common.withPosInt# n# (takeUnsafe# n#)
 {-# inline take# #-}
@@ -277,6 +283,9 @@ take# n# = Common.withPosInt# n# (takeUnsafe# n#)
 --   available.
 --
 -- Undefined behaviour if given a negative integer.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 takeUnsafe# :: Int# -> ParserT st e B.ByteString
 takeUnsafe# n# = ParserT \fp eob s st ->
     case n# <=# minusAddr# eob s of
@@ -285,6 +294,9 @@ takeUnsafe# n# = ParserT \fp eob s st ->
 {-# inline takeUnsafe# #-}
 
 -- | Consume the rest of the input. May return the empty bytestring.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 takeRest :: ParserT st e B.ByteString
 takeRest = ParserT \fp eob s st ->
   let n# = minusAddr# eob s

--- a/src/FlatParse/Stateful/Base.hs
+++ b/src/FlatParse/Stateful/Base.hs
@@ -264,6 +264,9 @@ withEnsure# n# (ParserT p) = ParserT \fp !r eob s n st ->
 --   available.
 --
 -- Throws a runtime error if given a negative integer.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 take :: Int -> ParserT st r e B.ByteString
 take (I# n#) = take# n#
 {-# inline take #-}
@@ -272,6 +275,9 @@ take (I# n#) = take# n#
 --   available.
 --
 -- Throws a runtime error if given a negative integer.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 take# :: Int# -> ParserT st r e B.ByteString
 take# n# = Common.withPosInt# n# (takeUnsafe# n#)
 {-# inline take# #-}
@@ -279,7 +285,10 @@ take# n# = Common.withPosInt# n# (takeUnsafe# n#)
 -- | Read @i#@ bytes as a 'ByteString'. Fails if newer than @i#@ bytes are
 --   available.
 --
---   Undefined behaviour if given a negative integer.
+-- Undefined behaviour if given a negative integer.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 takeUnsafe# :: Int# -> ParserT st r e B.ByteString
 takeUnsafe# i# = ParserT \fp !r eob s n st ->
     case i# <=# minusAddr# eob s of
@@ -288,6 +297,9 @@ takeUnsafe# i# = ParserT \fp !r eob s n st ->
 {-# inline takeUnsafe# #-}
 
 -- | Consume the rest of the input. May return the empty bytestring.
+--
+-- This does no copying. The 'B.ByteString' returned is a "slice" of the input,
+-- and will keep it alive. To avoid this, use 'B.copy' on the output.
 takeRest :: ParserT st r e B.ByteString
 takeRest = ParserT \fp !r eob s n st ->
   let i# = minusAddr# eob s


### PR DESCRIPTION
originally brought up in #39 