### PR TITLE
Add withError :: ParserT st e b -> (e -> ParserT st e b) -> ParserT st e b

### DIFF
--- a/src/FlatParse/Basic.hs
+++ b/src/FlatParse/Basic.hs
@@ -88,6 +88,7 @@ module FlatParse.Basic (
   , FP.Base.failed
   , FP.Base.try
   , FP.Base.err
+  , FP.Base.withError
   , FP.Base.fails
   , FP.Base.cut
   , FP.Base.cutting

--- a/src/FlatParse/Basic/Base.hs
+++ b/src/FlatParse/Basic/Base.hs
@@ -40,6 +40,7 @@ module FlatParse.Basic.Base
   , failed
   , try
   , err
+  , withError
   , fails
   , cut
   , cutting
@@ -70,6 +71,14 @@ failed = Control.Applicative.empty
 err :: e -> ParserT st e a
 err e = ParserT \_fp _eob _s st -> Err# st e
 {-# inline err #-}
+
+-- | Run the parser, if an error is thrown, handle it with the given function.
+withError :: ParserT st e b -> (e -> ParserT st e b) -> ParserT st e b
+withError (ParserT f) hdl = ParserT $ \fp eob s st -> case f fp eob s st of
+  Err# st' e -> case hdl e of
+    ParserT g -> g fp eob s st'
+  x -> x
+{-# inline withError #-}
 
 -- | Convert a parsing error into failure.
 try :: ParserT st e a -> ParserT st e a

--- a/src/FlatParse/Stateful.hs
+++ b/src/FlatParse/Stateful.hs
@@ -97,6 +97,7 @@ module FlatParse.Stateful (
   , FP.Base.failed
   , FP.Base.try
   , FP.Base.err
+  , FP.Base.withError
   , FP.Base.fails
   , FP.Base.cut
   , FP.Base.cutting

--- a/src/FlatParse/Stateful/Base.hs
+++ b/src/FlatParse/Stateful/Base.hs
@@ -40,6 +40,7 @@ module FlatParse.Stateful.Base
   , failed
   , try
   , err
+  , withError
   , fails
   , cut
   , cutting
@@ -70,6 +71,14 @@ failed = Control.Applicative.empty
 err :: e -> ParserT st r e a
 err e = ParserT \_fp !_r _eob _s _n st -> Err# st e
 {-# inline err #-}
+
+-- | Run the parser, if an error is thrown, handle it with the given function.
+withError :: ParserT st r e b -> (e -> ParserT st r e b) -> ParserT st r e b
+withError (ParserT f) hdl = ParserT $ \fp !r eob s n st -> case f fp r eob s n st of
+  Err# st' e -> case hdl e of
+    ParserT g -> g fp r eob s n st'
+  x -> x
+{-# inline withError #-}
 
 -- | Convert a parsing error into failure.
 try :: ParserT st r e a -> ParserT st r e a


### PR DESCRIPTION
While using `flatparse`, I found that it would be useful to have a function that handles errors in a more fine-grained manner, for example when dealing with an error type: `data Err = Err1 Bool | Err2 String`. This withError function should be able to manage those cases.

(The original code was written by `jannis_o` from the [Functional Programming discord server](https://discord.com/channels/280033776820813825/796099254937845790/1132370231994613761).

Also, I thought about adding this other function to the PR. Though I don't know if it is a sufficiently general parser to be added to the package.
```haskell
tryUntilEOF :: ParserT st r e a -> ParserT st r e [a]
tryUntilEOF (ParserT f) = ParserT go
  where
    go fp !r eob s n st =
      case f fp r eob s n st of
        OK# st a s n ->
          case go fp r eob s n st of
            OK# st as s n -> OK# st (a : as) s n
            x -> x
        Fail# st ->
          let (ParserT b) =
                branch
                  eof
                  (pure [])
                  ( branch
                      (skip 1)
                      (tryUntilEOF (ParserT f))
                      (pure [])
                  )
           in b fp r eob s n st
        Err# st e -> Err# st e
```
Basically, it tries to consume the entire input using a given parser, in order to give a list with the results.  (The function in this state isn't optimized)