### PR TITLE
Forces values in in `withAnySizeUnnsafe#`

### DIFF
--- a/src/FlatParse/Basic/Integers.hs
+++ b/src/FlatParse/Basic/Integers.hs
@@ -71,9 +71,8 @@ withAnySized# size# indexOffAddr p =
 withAnySizedUnsafe#
     :: Int# -> (Addr# -> Int# -> a) -> (a -> ParserT st e r) -> ParserT st e r
 withAnySizedUnsafe# size# indexOffAddr p = ParserT \fp eob buf st ->
--- TODO force? i.e. @let !a, !buf'@ ?
-  let a    = indexOffAddr buf 0#
-      buf' = plusAddr# buf size#
+  let !a    = indexOffAddr buf 0#
+      !buf' = plusAddr# buf size#
   in  runParserT# (p a) fp eob buf' st
 {-# inline withAnySizedUnsafe# #-}
 

--- a/src/FlatParse/Basic/Integers.hs
+++ b/src/FlatParse/Basic/Integers.hs
@@ -71,8 +71,8 @@ withAnySized# size# indexOffAddr p =
 withAnySizedUnsafe#
     :: Int# -> (Addr# -> Int# -> a) -> (a -> ParserT st e r) -> ParserT st e r
 withAnySizedUnsafe# size# indexOffAddr p = ParserT \fp eob buf st ->
-  let !a    = indexOffAddr buf 0#
-      !buf' = plusAddr# buf size#
+  let !a   = indexOffAddr buf 0#
+      buf' = plusAddr# buf size#
   in  runParserT# (p a) fp eob buf' st
 {-# inline withAnySizedUnsafe# #-}
 


### PR DESCRIPTION
This appears to fix a hard to uncover concurrency issue that I ran into while running Hedgehog properties in parallel to verify the encoding and decoding of data structures in our code. The tests would fail intermittently with only the multibyte integer values in the data structures shown as decoding incorrectly. Re-running the property with the failing seed would pass. Also running only 1 thread of tests or disabling the threaded runtime would also make the the tests pass.
