### PR TITLE
Fix usage of `WORDS_BIGENDIAN` CPP macros

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,25 +5,26 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1673362319,
-        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
-        "id": "flake-parts",
-        "type": "indirect"
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1673460110,
-        "narHash": "sha256-D4J7FfHOrLPIZBmypjuwxXriOhOnxllUeYkmLzTcc2M=",
+        "lastModified": 1709467224,
+        "narHash": "sha256-xnPTkLMqq78BiTqt6WXj2TXLupclJi+NEH84HDbQSPc=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "6a56fbd3e4bb7e040b5ac98ba9fe7afcb5e285c0",
+        "rev": "9173cc45aeb72b7e7adfe0e5a53a425fe439e3ca",
         "type": "github"
       },
       "original": {
@@ -34,26 +35,28 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673606088,
-        "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
-        "owner": "NixOS",
+        "lastModified": 1709641832,
+        "narHash": "sha256-bzzRc3DiV8Cm/67HDa39pyBymqF45ISgUbXqjrMk2UE=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "37b97ae3dd714de9a17923d004a2c5b5543dfa6d",
+        "rev": "bfa8b30043892dc2b660d403faa159bab7b65898",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1672350804,
-        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,47 @@
 {
   inputs = {
-    #nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    #flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
   };
-  outputs = inputs@{ nixpkgs, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = nixpkgs.lib.systems.flakeExposed;
+  outputs = inputs:
+  let
+    # simple devshell for non-dev compilers: really just want `cabal repl`
+    nondevDevShell = compiler: {
+      mkShellArgs.name = "${compiler}-flatparse";
+      hoogle = false;
+      tools = _: {
+        hlint = null;
+        haskell-language-server = null;
+        ghcid = null;
+      };
+    };
+  in
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
       imports = [ inputs.haskell-flake.flakeModule ];
-      perSystem = { self', pkgs, ... }: {
-        haskellProjects.default = {
-          haskellPackages = pkgs.haskell.packages.ghc944;
-          #haskellPackages = pkgs.haskell.packages.ghc925;
-          #haskellPackages = pkgs.haskell.packages.ghc810;
-          packages = {
-            flatparse.root = ./.;
+      perSystem = { self', pkgs, config, ... }: {
+        packages.default  = self'.packages.ghc96-flatparse;
+        devShells.default = self'.devShells.ghc96;
+        haskellProjects.ghc98 = {
+          # shouldn't work, pkgs aren't up to date and mine aren't 9.8 ready
+          basePackages = pkgs.haskell.packages.ghc98;
+          devShell = nondevDevShell "ghc98";
+        };
+        haskellProjects.ghc96 = {
+          basePackages = pkgs.haskell.packages.ghc96;
+          devShell.mkShellArgs.name = "ghc96-flatparse";
+          devShell.tools = _: {
+            haskell-language-server = null; # 2024-03-06: broken
           };
-          # 2023-01-12 raehik: ghcid seems broken on nixpkgs GHC 9.4.{3,4}
-          buildTools = hp: { ghcid = null; hls = null; };
-          # overrides = self: super: { }
-          # hlintCheck.enable = true;
-          # hlsCheck.enable = true;
+        };
+        haskellProjects.ghc94 = {
+          basePackages = pkgs.haskell.packages.ghc94;
+          devShell = nondevDevShell "ghc94";
+        };
+        haskellProjects.ghc92 = {
+          basePackages = pkgs.haskell.packages.ghc92;
+          devShell = nondevDevShell "ghc92";
         };
       };
     };

--- a/src/FlatParse/Basic.hs
+++ b/src/FlatParse/Basic.hs
@@ -157,6 +157,9 @@ module FlatParse.Basic (
 
   ) where
 
+-- for WORDS_BIGENDIAN
+#include "MachDeps.h"
+
 import FlatParse.Basic.Parser
 import FlatParse.Basic.Base
 import FlatParse.Basic.Integers
@@ -494,7 +497,7 @@ isolateToNextNull (ParserT p) = ParserT \fp eob s st -> go fp eob s st s
             -- reading could probably segfault
             go8 fp eob s0 st s
           _  -> -- >= 8 bytes of input: use efficient 8-byte scanning
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
             -- big-endian ("L->R"): find leftmost null byte
             let !x@(I# x#) = Common.zbytel'intermediate (I# (indexIntOffAddr# s 0#)) in
 #else
@@ -504,7 +507,7 @@ isolateToNextNull (ParserT p) = ParserT \fp eob s st -> go fp eob s st s
             case x# ==# 0# of
               1# -> go fp eob s0 st sWord -- no 0x00 in next word
               _  -> -- 0x00 somewhere in next word
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
                 let !(I# nullIdx#) = Common.zbytel'toIdx x in
 #else
                 let !(I# nullIdx#) = Common.zbyter'toIdx x in

--- a/src/FlatParse/Basic/Integers.hs
+++ b/src/FlatParse/Basic/Integers.hs
@@ -36,6 +36,9 @@ module FlatParse.Basic.Integers
   , sizedUnsafe#
   ) where
 
+-- for WORDS_BIGENDIAN
+#include "MachDeps.h"
+
 import FlatParse.Basic.Parser
 import FlatParse.Basic.Base ( withEnsure# )
 
@@ -204,7 +207,7 @@ is inlined as a single @BSWAP@ instruction.
 
 -- | Parse any 'Word16' (little-endian).
 anyWord16le :: ParserT st e Word16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord16le = withAnyWord16 (pure . byteSwap16)
 #else
 anyWord16le = anyWord16
@@ -213,7 +216,7 @@ anyWord16le = anyWord16
 
 -- | Parse any 'Word16' (big-endian).
 anyWord16be :: ParserT st e Word16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord16be = anyWord16
 #else
 anyWord16be = withAnyWord16 (pure . byteSwap16)
@@ -222,7 +225,7 @@ anyWord16be = withAnyWord16 (pure . byteSwap16)
 
 -- | Parse any 'Word32' (little-endian).
 anyWord32le :: ParserT st e Word32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord32le = withAnyWord32 (pure . byteSwap32)
 #else
 anyWord32le = anyWord32
@@ -231,7 +234,7 @@ anyWord32le = anyWord32
 
 -- | Parse any 'Word32' (big-endian).
 anyWord32be :: ParserT st e Word32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord32be = anyWord32
 #else
 anyWord32be = withAnyWord32 (pure . byteSwap32)
@@ -240,7 +243,7 @@ anyWord32be = withAnyWord32 (pure . byteSwap32)
 
 -- | Parse any 'Word64' (little-endian).
 anyWord64le :: ParserT st e Word64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord64le = withAnyWord64 (pure . byteSwap64)
 #else
 anyWord64le = anyWord64
@@ -249,7 +252,7 @@ anyWord64le = anyWord64
 
 -- | Parse any 'Word64' (big-endian).
 anyWord64be :: ParserT st e Word64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord64be = anyWord64
 #else
 anyWord64be = withAnyWord64 (pure . byteSwap64)
@@ -258,7 +261,7 @@ anyWord64be = withAnyWord64 (pure . byteSwap64)
 
 -- | Parse any 'Int16' (little-endian).
 anyInt16le :: ParserT st e Int16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt16le = withAnyWord16 (pure . word16ToInt16 . byteSwap16)
 #else
 anyInt16le = anyInt16
@@ -267,7 +270,7 @@ anyInt16le = anyInt16
 
 -- | Parse any 'Int16' (big-endian).
 anyInt16be :: ParserT st e Int16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt16be = anyInt16
 #else
 anyInt16be = withAnyWord16 (pure . word16ToInt16 . byteSwap16)
@@ -276,7 +279,7 @@ anyInt16be = withAnyWord16 (pure . word16ToInt16 . byteSwap16)
 
 -- | Parse any 'Int32' (little-endian).
 anyInt32le :: ParserT st e Int32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt32le = withAnyWord32 (pure . word32ToInt32 . byteSwap32)
 #else
 anyInt32le = anyInt32
@@ -285,7 +288,7 @@ anyInt32le = anyInt32
 
 -- | Parse any 'Int32' (big-endian).
 anyInt32be :: ParserT st e Int32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt32be = anyInt32
 #else
 anyInt32be = withAnyWord32 (pure . word32ToInt32 . byteSwap32)
@@ -294,7 +297,7 @@ anyInt32be = withAnyWord32 (pure . word32ToInt32 . byteSwap32)
 
 -- | Parse any 'Int64' (little-endian).
 anyInt64le :: ParserT st e Int64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt64le = withAnyWord64 (pure . word64ToInt64 . byteSwap64)
 #else
 anyInt64le = anyInt64
@@ -303,7 +306,7 @@ anyInt64le = anyInt64
 
 -- | Parse any 'Int64' (big-endian).
 anyInt64be :: ParserT st e Int64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt64be = anyInt64
 #else
 anyInt64be = withAnyWord64 (pure . word64ToInt64 . byteSwap64)

--- a/src/FlatParse/Stateful.hs
+++ b/src/FlatParse/Stateful.hs
@@ -166,6 +166,8 @@ module FlatParse.Stateful (
 
   ) where
 
+-- for WORDS_BIGENDIAN
+#include "MachDeps.h"
 
 import qualified FlatParse.Basic as Basic
 import FlatParse.Stateful.Parser
@@ -472,7 +474,7 @@ isolateToNextNull (ParserT p) = ParserT \fp !r eob s n st -> go fp r n eob s st 
             -- reading could probably segfault
             go8 fp r n eob s0 st s
           _  -> -- >= 8 bytes of input: use efficient 8-byte scanning
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
             -- big-endian ("L->R"): find leftmost null byte
             let !x@(I# x#) = Common.zbytel'intermediate (I# (indexIntOffAddr# s 0#)) in
 #else
@@ -482,7 +484,7 @@ isolateToNextNull (ParserT p) = ParserT \fp !r eob s n st -> go fp r n eob s st 
             case x# ==# 0# of
               1# -> go fp r n eob s0 st sWord -- no 0x00 in next word
               _  -> -- 0x00 somewhere in next word
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
                 let !(I# nullIdx#) = Common.zbytel'toIdx x in
 #else
                 let !(I# nullIdx#) = Common.zbyter'toIdx x in

--- a/src/FlatParse/Stateful/Integers.hs
+++ b/src/FlatParse/Stateful/Integers.hs
@@ -36,6 +36,9 @@ module FlatParse.Stateful.Integers
   , sizedUnsafe#
   ) where
 
+-- for WORDS_BIGENDIAN
+#include "MachDeps.h"
+
 import FlatParse.Stateful.Parser
 import FlatParse.Stateful.Base ( withEnsure# )
 
@@ -206,7 +209,7 @@ is inlined as a single @BSWAP@ instruction.
 
 -- | Parse any 'Word16' (little-endian).
 anyWord16le :: ParserT st r e Word16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord16le = withAnyWord16 (pure . byteSwap16)
 #else
 anyWord16le = anyWord16
@@ -215,7 +218,7 @@ anyWord16le = anyWord16
 
 -- | Parse any 'Word16' (big-endian).
 anyWord16be :: ParserT st r e Word16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord16be = anyWord16
 #else
 anyWord16be = withAnyWord16 (pure . byteSwap16)
@@ -224,7 +227,7 @@ anyWord16be = withAnyWord16 (pure . byteSwap16)
 
 -- | Parse any 'Word32' (little-endian).
 anyWord32le :: ParserT st r e Word32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord32le = withAnyWord32 (pure . byteSwap32)
 #else
 anyWord32le = anyWord32
@@ -233,7 +236,7 @@ anyWord32le = anyWord32
 
 -- | Parse any 'Word32' (big-endian).
 anyWord32be :: ParserT st r e Word32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord32be = anyWord32
 #else
 anyWord32be = withAnyWord32 (pure . byteSwap32)
@@ -242,7 +245,7 @@ anyWord32be = withAnyWord32 (pure . byteSwap32)
 
 -- | Parse any 'Word64' (little-endian).
 anyWord64le :: ParserT st r e Word64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord64le = withAnyWord64 (pure . byteSwap64)
 #else
 anyWord64le = anyWord64
@@ -251,7 +254,7 @@ anyWord64le = anyWord64
 
 -- | Parse any 'Word64' (big-endian).
 anyWord64be :: ParserT st r e Word64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyWord64be = anyWord64
 #else
 anyWord64be = withAnyWord64 (pure . byteSwap64)
@@ -260,7 +263,7 @@ anyWord64be = withAnyWord64 (pure . byteSwap64)
 
 -- | Parse any 'Int16' (little-endian).
 anyInt16le :: ParserT st r e Int16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt16le = withAnyWord16 (pure . word16ToInt16 . byteSwap16)
 #else
 anyInt16le = anyInt16
@@ -269,7 +272,7 @@ anyInt16le = anyInt16
 
 -- | Parse any 'Int16' (big-endian).
 anyInt16be :: ParserT st r e Int16
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt16be = anyInt16
 #else
 anyInt16be = withAnyWord16 (pure . word16ToInt16 . byteSwap16)
@@ -278,7 +281,7 @@ anyInt16be = withAnyWord16 (pure . word16ToInt16 . byteSwap16)
 
 -- | Parse any 'Int32' (little-endian).
 anyInt32le :: ParserT st r e Int32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt32le = withAnyWord32 (pure . word32ToInt32 . byteSwap32)
 #else
 anyInt32le = anyInt32
@@ -287,7 +290,7 @@ anyInt32le = anyInt32
 
 -- | Parse any 'Int32' (big-endian).
 anyInt32be :: ParserT st r e Int32
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt32be = anyInt32
 #else
 anyInt32be = withAnyWord32 (pure . word32ToInt32 . byteSwap32)
@@ -296,7 +299,7 @@ anyInt32be = withAnyWord32 (pure . word32ToInt32 . byteSwap32)
 
 -- | Parse any 'Int64' (little-endian).
 anyInt64le :: ParserT st r e Int64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt64le = withAnyWord64 (pure . word64ToInt64 . byteSwap64)
 #else
 anyInt64le = anyInt64
@@ -305,7 +308,7 @@ anyInt64le = anyInt64
 
 -- | Parse any 'Int64' (big-endian).
 anyInt64be :: ParserT st r e Int64
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN)
 anyInt64be = anyInt64
 #else
 anyInt64be = withAnyWord64 (pure . word64ToInt64 . byteSwap64)


### PR DESCRIPTION
This is provided by `MachDeps.h`, which we never `#include` d, so these clauses would never be used. We now `#include` it where required, and I reformatted the CPP checks to look like GHC (which uses `#if defined(WORDS_BIGENDIAN)`).

Also separately adds a quick Nix build file fix.