### PR TITLE
add parseWithLength

### DIFF
--- a/src/FlatParse/Basic.hs
+++ b/src/FlatParse/Basic.hs
@@ -85,6 +85,7 @@ module FlatParse.Basic (
   , FP.Base.skipMany
   , Control.Applicative.some
   , FP.Base.skipSome
+  , parseWithLength
 
   -- ** Errors and failures
   , Control.Applicative.empty
@@ -377,6 +378,16 @@ inSpan (Span s eob) (ParserT f) = ParserT \fp eob' s' st ->
 {-# inline inSpan #-}
 
 --------------------------------------------------------------------------------
+
+-- | Run a parser, and return the result as well as the number of bytes it
+--   consumed.
+parseWithLength :: ParserT st e a -> ParserT st e (a, Int)
+parseWithLength (ParserT f) = ParserT \fp eob s st -> do
+    case f fp eob s st of
+      Fail# st'      -> Fail# st'
+      Err#  st' e    -> Err#  st' e
+      OK#   st' a s' -> OK#   st' (a, I# (s' `minusAddr#` s)) s'
+{-# inline parseWithLength #-}
 
 -- | Create a 'B.ByteString' from a 'Span'.
 --


### PR DESCRIPTION
Returns parse result along with number of bytes consumed. Maybe useful for low level binary parsing.

* [ ] Add Stateful version
* [ ] Figure out a better name?
* [ ] Add some basic tests (parse a bytestring of length N (QuickCheck prop), parse a Word32)