### PR TITLE
Fix native byte order `Int`/`Word` parsers on 32-bit

### DIFF
--- a/src/FlatParse/Basic/Integers.hs
+++ b/src/FlatParse/Basic/Integers.hs
@@ -127,7 +127,7 @@ withAnyInt64 = withAnySized# 8# (\a i -> I64# (indexInt64OffAddr# a i))
 
 -- | Parse any 'Word' (native size) (CPS).
 withAnyWord :: (Word -> ParserT st e r) -> ParserT st e r
-withAnyWord p = ParserT \fp eob buf st -> case 8# <=# minusAddr# eob buf of
+withAnyWord p = ParserT \fp eob buf st -> case SIZEOF_HSWORD# <=# minusAddr# eob buf of
   0# -> Fail# st
   _  -> let w# = indexWordOffAddr# buf 0#
         in  runParserT# (p (W# w#)) fp eob (plusAddr# buf SIZEOF_HSWORD#) st
@@ -135,7 +135,7 @@ withAnyWord p = ParserT \fp eob buf st -> case 8# <=# minusAddr# eob buf of
 
 -- | Parse any 'Int' (native size) (CPS).
 withAnyInt :: (Int -> ParserT st e r) -> ParserT st e r
-withAnyInt p = ParserT \fp eob buf st -> case 8# <=# minusAddr# eob buf of
+withAnyInt p = ParserT \fp eob buf st -> case SIZEOF_HSWORD# <=# minusAddr# eob buf of
   0# -> Fail# st
   _  -> let i# = indexIntOffAddr# buf 0#
         in  runParserT# (p (I# i#)) fp eob (plusAddr# buf SIZEOF_HSWORD#) st

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -368,11 +368,52 @@ basicSpec = describe "FlatParse.Basic" $ do
       it "fails on insufficient input" $
         FB.anyWord32 `shouldParseFail` "\xff\xff\xff"
 
+    describe "anyWord64" $ do
+      -- Byte order is unspecified, so just assert that it succeeds.
+      it "succeeds" $ FB.anyWord64 `shouldParse` "\xef\xbe\xae\x7e\xff\xb1\xc2\xd3"
+
+      it "fails on empty input" $ FB.anyWord64 `shouldParseFail` ""
+      it "fails on insufficient input" $
+        FB.anyWord64 `shouldParseFail` "\xff\xff\xff\xff\xff\xff\xff"
+
     describe "anyWord" $ do
       -- Byte order is unspecified, so just assert that it succeeds.
       it "succeeds" $ FB.anyWord `shouldParse` B.replicate SIZEOF_HSWORD 0xef
 
       it "fails on FB.empty input" $ FB.anyWord `shouldParseFail` ""
+
+    describe "anyInt8" $ do
+      it "reads a byte" $ FB.anyInt8 `shouldParseWith` ("\x2f", 0x2f)
+      it "fails on FB.empty input" $ FB.anyInt8 `shouldParseFail` ""
+
+    describe "anyInt16" $ do
+      -- Byte order is unspecified, so just assert that it succeeds.
+      it "succeeds" $ FB.anyInt16 `shouldParse` "\xef\xbe"
+
+      it "fails on FB.empty input" $ FB.anyInt16 `shouldParseFail` ""
+      it "fails on insufficient input" $ FB.anyInt16 `shouldParseFail` "\xff"
+
+    describe "anyInt32" $ do
+      -- Byte order is unspecified, so just assert that it succeeds.
+      it "succeeds" $ FB.anyInt32 `shouldParse` "\xef\xbe\xae\x7e"
+
+      it "fails on empty input" $ FB.anyInt32 `shouldParseFail` ""
+      it "fails on insufficient input" $
+        FB.anyInt32 `shouldParseFail` "\xff\xff\xff"
+
+    describe "anyInt64" $ do
+      -- Byte order is unspecified, so just assert that it succeeds.
+      it "succeeds" $ FB.anyInt64 `shouldParse` "\xef\xbe\xae\x7e\xff\xb1\xc2\xd3"
+
+      it "fails on empty input" $ FB.anyInt64 `shouldParseFail` ""
+      it "fails on insufficient input" $
+        FB.anyInt64 `shouldParseFail` "\xff\xff\xff\xff\xff\xff\xff"
+
+    describe "anyInt" $ do
+      -- Byte order is unspecified, so just assert that it succeeds.
+      it "succeeds" $ FB.anyInt `shouldParse` B.replicate SIZEOF_HSWORD 0xef
+
+      it "fails on FB.empty input" $ FB.anyInt `shouldParseFail` ""
 
     describe "anyChar" $ do
       it "reads 1-byte char" $ FB.anyChar `shouldParseWith` (UTF8.fromString "$", '$')

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -369,8 +369,9 @@ basicSpec = describe "FlatParse.Basic" $ do
         FB.anyWord32 `shouldParseFail` "\xff\xff\xff"
 
     describe "anyWord" $ do
-      -- This combinator is inherently non-portable, but we know a Word is at
-      -- least some bytes.
+      -- Byte order is unspecified, so just assert that it succeeds.
+      it "succeeds" $ FB.anyWord `shouldParse` B.replicate SIZEOF_HSWORD 0xef
+
       it "fails on FB.empty input" $ FB.anyWord `shouldParseFail` ""
 
     describe "anyChar" $ do


### PR DESCRIPTION
This PR fixes an oversight by me from #67, see the third commit. The first two commits add appropriate regression tests.